### PR TITLE
Generalize detection of biozsh directory

### DIFF
--- a/biozsh.zsh
+++ b/biozsh.zsh
@@ -1,8 +1,11 @@
 #/usr/bin/zsh
 
+# determine biozsh directory
+BIOZSH_DIR="${funcsourcetrace[1]%/*}"
+
 # add completions
-fpath+=($PWD/completions)
+fpath+=("${BIOZSH_DIR}/completions")
 compinit
 
 # initialise wrappers
-alias figtree="$PWD/wrappers/figtree"
+alias figtree="${BIOZSH_DIR}/wrappers/figtree"


### PR DESCRIPTION
Fix #2 
There might be more elegant ways to determine the absolute location of the sourced zsh file.
Only tested with direct sourcing and `antigen`, not `zgen`.